### PR TITLE
[fix] 글 작성 플로우 네비바 수정

### DIFF
--- a/ReadMe-iOS/ReadMe-iOS.xcodeproj/project.pbxproj
+++ b/ReadMe-iOS/ReadMe-iOS.xcodeproj/project.pbxproj
@@ -48,7 +48,7 @@
 		2BB0C3C4282957930013374B /* FeedReportEntity.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2BB0C3BE282957930013374B /* FeedReportEntity.swift */; };
 		2BB0C3C6282958230013374B /* FeedReport.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 2BB0C3C5282958230013374B /* FeedReport.storyboard */; };
 		2BB0C3C8282972710013374B /* FeedListDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2BB0C3C7282972710013374B /* FeedListDelegate.swift */; };
-		2BC08C662826AF8B003F0139 /* ProgressBar.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2BC08C652826AF8B003F0139 /* ProgressBar.swift */; };
+		2BB3F8C4282E163800E2823E /* CustomNavigationBar.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2BB3F8C3282E163800E2823E /* CustomNavigationBar.swift */; };
 		2BD34FAB281F95690043EBD6 /* BottomSheetVC.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2BD34FAA281F95690043EBD6 /* BottomSheetVC.swift */; };
 		2BD34FAD281F95720043EBD6 /* BottomSheet.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 2BD34FAC281F95720043EBD6 /* BottomSheet.storyboard */; };
 		2BD922CB282417FD00B23510 /* leftAlignment + UICollectionView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2BD922CA282417FD00B23510 /* leftAlignment + UICollectionView.swift */; };
@@ -253,7 +253,7 @@
 		2BB0C3BE282957930013374B /* FeedReportEntity.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeedReportEntity.swift; sourceTree = "<group>"; };
 		2BB0C3C5282958230013374B /* FeedReport.storyboard */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; path = FeedReport.storyboard; sourceTree = "<group>"; };
 		2BB0C3C7282972710013374B /* FeedListDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeedListDelegate.swift; sourceTree = "<group>"; };
-		2BC08C652826AF8B003F0139 /* ProgressBar.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ProgressBar.swift; sourceTree = "<group>"; };
+		2BB3F8C3282E163800E2823E /* CustomNavigationBar.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomNavigationBar.swift; sourceTree = "<group>"; };
 		2BD34FAA281F95690043EBD6 /* BottomSheetVC.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BottomSheetVC.swift; sourceTree = "<group>"; };
 		2BD34FAC281F95720043EBD6 /* BottomSheet.storyboard */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; path = BottomSheet.storyboard; sourceTree = "<group>"; };
 		2BD922CA282417FD00B23510 /* leftAlignment + UICollectionView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "leftAlignment + UICollectionView.swift"; sourceTree = "<group>"; };
@@ -698,6 +698,14 @@
 				2BB0C3C5282958230013374B /* FeedReport.storyboard */,
 			);
 			path = VIews;
+			sourceTree = "<group>";
+		};
+		2BB3F8C2282E15FE00E2823E /* CustomNavigationBar */ = {
+			isa = PBXGroup;
+			children = (
+				2BB3F8C3282E163800E2823E /* CustomNavigationBar.swift */,
+			);
+			path = CustomNavigationBar;
 			sourceTree = "<group>";
 		};
 		2BD34FA9281F954F0043EBD6 /* BottomSheet */ = {
@@ -1253,6 +1261,7 @@
 		FD99D5A728073D8E00BB7FDA /* Component */ = {
 			isa = PBXGroup;
 			children = (
+				2BB3F8C2282E15FE00E2823E /* CustomNavigationBar */,
 				2BD34FA9281F954F0043EBD6 /* BottomSheet */,
 				2B6DED8E28106786002BD931 /* ProgressBar */,
 				FD99D5A828073DA100BB7FDA /* Button */,
@@ -2034,6 +2043,7 @@
 				2B7DCCA7280E7E490062BAE8 /* WriteViewModel.swift in Sources */,
 				2BA6EB5C2811D2B100715C31 /* WriteCheckEntity.swift in Sources */,
 				FD0619872805586200F647D7 /* TabbarIcon.swift in Sources */,
+				2BB3F8C4282E163800E2823E /* CustomNavigationBar.swift in Sources */,
 				FD106C52280E96BD00D803D8 /* UsecaseType.swift in Sources */,
 				FDD9D2FB27F9E3870024DFB2 /* LaunchInstructor.swift in Sources */,
 				FD99D59B28073C4900BB7FDA /* SignupViewModel.swift in Sources */,

--- a/ReadMe-iOS/ReadMe-iOS/Presentation/Component/CustomNavigationBar/CustomNavigationBar.swift
+++ b/ReadMe-iOS/ReadMe-iOS/Presentation/Component/CustomNavigationBar/CustomNavigationBar.swift
@@ -1,0 +1,69 @@
+//
+//  CustomNavigationBar.swift
+//  ReadMe-iOS
+//
+//  Created by 양수빈 on 2022/05/13.
+//
+
+import UIKit
+
+import SnapKit
+
+final class CustomNavigationBar: UIView {
+  
+  // MARK: - UI Component Part
+  
+  private var vc: UIViewController?
+  let backButton = UIButton()
+  
+  // MARK: - Initialize Part
+  
+  init(_ vc: UIViewController) {
+    super.init(frame: .zero)
+    self.vc = vc
+    configureUI()
+    setLayout()
+  }
+  
+  required init?(coder: NSCoder) {
+    fatalError("init(coder:) has not been implemented")
+  }
+}
+
+extension CustomNavigationBar {
+  
+  // MARK: - UI & Layout Part
+  
+  private func configureUI() {
+    backButton.setImage(ImageLiterals.NavigationBar.back, for: .normal)
+  }
+  
+  private func setLayout() {
+    self.addSubview(backButton)
+    
+    self.snp.makeConstraints { make in
+      make.height.equalTo(54)
+    }
+    
+    backButton.snp.makeConstraints { make in
+      make.leading.equalToSuperview().inset(20)
+      make.centerY.equalToSuperview()
+    }
+  }
+  
+  // MARK: - Custom Method
+  
+  private func popToPreviousVC() {
+    self.vc?.navigationController?.popViewController(animated: true)
+  }
+  
+  @discardableResult
+  func setDefaultBackButtonAction() -> Self {
+    // 기본적으로는 pop 하는 액션
+    // 그 외에는 추가할 수 있도록
+    backButton.press {
+      self.popToPreviousVC()
+    }
+    return self
+  }
+}

--- a/ReadMe-iOS/ReadMe-iOS/Presentation/WriteCheckScene/VC/WriteCheckVC.swift
+++ b/ReadMe-iOS/ReadMe-iOS/Presentation/WriteCheckScene/VC/WriteCheckVC.swift
@@ -14,8 +14,7 @@ class WriteCheckVC: UIViewController {
   
   // MARK: - Vars & Lets Part
   
-  private let naviBar = UIView()
-  private let backButton = UIButton()
+  private lazy var naviBar = CustomNavigationBar(self).setDefaultBackButtonAction()
   private let titleLabel = UILabel()
   private let bgImageView = UIImageView()
   private let quoteTextView = UITextView()
@@ -46,7 +45,6 @@ class WriteCheckVC: UIViewController {
     self.setLayout()
     self.bindViewModels()
     self.setPreviousData()
-    self.setButtonActions()
   }
   
   open override func didMove(toParent parent: UIViewController?) {
@@ -57,11 +55,6 @@ class WriteCheckVC: UIViewController {
 // MARK: - Custom Method Part
 
 extension WriteCheckVC {
-  private func setButtonActions() {
-    backButton.press {
-      self.navigationController?.popViewController(animated: true)
-    }
-  }
   
   private func bindViewModels() {
     let input = WriteCheckViewModel.Input(
@@ -130,8 +123,6 @@ extension WriteCheckVC {
 extension WriteCheckVC {
   private func configureUI() {
     view.backgroundColor = .grey00
-    
-    backButton.setImage(ImageLiterals.NavigationBar.back, for: .normal)
     
     titleLabel.text = I18N.WriteCheck.titleThrough + username +  I18N.WriteCheck.titleDay
     titleLabel.numberOfLines = 2
@@ -206,17 +197,9 @@ extension WriteCheckVC {
                      dateLabel, bookCoverImageView, categoryLabel,
                       bookTitleLabel, bookAuthorLabel, registerButton])
     
-    naviBar.addSubview(backButton)
-    
     naviBar.snp.makeConstraints { make in
       make.leading.trailing.equalToSuperview()
       make.top.equalTo(view.safeAreaLayoutGuide)
-      make.height.equalTo(54)
-    }
-    
-    backButton.snp.makeConstraints { make in
-      make.leading.equalToSuperview().inset(20)
-      make.centerY.equalToSuperview()
     }
     
     titleLabel.snp.makeConstraints { make in

--- a/ReadMe-iOS/ReadMe-iOS/Presentation/WriteCompleteScene/VC/WriteCompleteVC.swift
+++ b/ReadMe-iOS/ReadMe-iOS/Presentation/WriteCompleteScene/VC/WriteCompleteVC.swift
@@ -17,8 +17,6 @@ final class WriteCompleteVC: UIViewController {
   var viewModel: WriteCompleteViewModel!
   
   // MARK: - UI Component Part
-  private let naviBar = UIView()
-  private let backButton = UIButton()
   private let checkImageView = UIImageView()
   private let titleLabel = UILabel()
   private let subtitleLabel = UILabel()
@@ -30,19 +28,12 @@ final class WriteCompleteVC: UIViewController {
     self.configureUI()
     self.setLayout()
     self.bindViewModels()
-    self.setButtonActions()
   }
 }
 
 extension WriteCompleteVC {
   
   // MARK: - Custom Method Part
-  
-  private func setButtonActions() {
-    backButton.press {
-      self.navigationController?.popViewController(animated: true)
-    }
-  }
   
   private func bindViewModels() {
     let input = WriteCompleteViewModel.Input()
@@ -61,8 +52,6 @@ extension WriteCompleteVC {
 
 extension WriteCompleteVC {
   private func configureUI() {
-    backButton.setImage(ImageLiterals.NavigationBar.back, for: .normal)
-    
     checkImageView.image = ImageLiterals.WriteComplete.check
     
     titleLabel.text = I18N.WriteComplete.title
@@ -90,21 +79,7 @@ extension WriteCompleteVC {
 
 extension WriteCompleteVC {
   private func setLayout() {
-    view.addSubviews([naviBar, checkImageView, titleLabel,
-                      subtitleLabel, moveButton])
-    
-    naviBar.addSubview(backButton)
-    
-    naviBar.snp.makeConstraints { make in
-      make.leading.trailing.equalToSuperview()
-      make.top.equalTo(view.safeAreaLayoutGuide)
-      make.height.equalTo(54)
-    }
-    
-    backButton.snp.makeConstraints { make in
-      make.leading.equalToSuperview().inset(20)
-      make.centerY.equalToSuperview()
-    }
+    view.addSubviews([checkImageView, titleLabel, subtitleLabel, moveButton])
     
     checkImageView.snp.makeConstraints { make in
       make.top.equalTo(view.safeAreaLayoutGuide).inset(UIScreen.main.bounds.height * 0.32)

--- a/ReadMe-iOS/ReadMe-iOS/Presentation/WriteScene/VC/WriteVC.swift
+++ b/ReadMe-iOS/ReadMe-iOS/Presentation/WriteScene/VC/WriteVC.swift
@@ -22,8 +22,7 @@ class WriteVC: UIViewController {
   
   // MARK: - Vars & Lets Part
   
-  private let naviBar = UIView()
-  private let backButton = UIButton()
+  private lazy var naviBar = CustomNavigationBar(self)
   private let topBgView = UIView()
   private let cheerLabel = UILabel()
   private let describeLabel = UILabel()
@@ -96,7 +95,7 @@ extension WriteVC {
   }
   
   private func setButtonActions() {
-    backButton.press {
+    naviBar.backButton.press {
       switch self.flowType {
       case .firstFlow:
         self.navigationController?.popViewController(animated: true)
@@ -320,7 +319,6 @@ extension WriteVC: UITextViewDelegate {
 
 extension WriteVC {
   private func configureUI() {
-    backButton.setImage(ImageLiterals.NavigationBar.back, for: .normal)
     topBgView.backgroundColor = .grey00
     
     progressBar.setPercentage(ratio: 0.0)
@@ -344,17 +342,9 @@ extension WriteVC {
                       describeLabel, firstView, secondView,
                       thirdView, progressBar, nextButton])
     
-    naviBar.addSubview(backButton)
-    
     naviBar.snp.makeConstraints { make in
       make.leading.trailing.equalToSuperview()
       make.top.equalTo(view.safeAreaLayoutGuide)
-      make.height.equalTo(54)
-    }
-    
-    backButton.snp.makeConstraints { make in
-      make.leading.equalToSuperview().inset(20)
-      make.centerY.equalToSuperview()
     }
     
     cheerLabel.snp.makeConstraints { make in


### PR DESCRIPTION
## ✨ 작업 내용 
- [x] 글 작성 완료 뷰 네비바(뒤로가기) 삭제
- [x] 글 작성 플로우 CustomNavigationBar 분리


## 📸 스크린샷(선택)

## ⚙️ 관계된 이슈, PR : 
closed #49 

## 📚 레퍼런스 (또는 새로 알게 된 내용) 혹은 궁금한 사항들
backButton을 private로 설정하고 액션도 같이 넣어주고 싶었는데,
글 작성 플로우에서 항상 뒤로가기 버튼이 pop 액션을 하는게 아니라 일단은 VC에서도 접근해서 따로 액션을 넣을 수 있도록 했습니닫


