### PR TITLE
[fix] 글작성 플로우 작성한 글이 없는 경우 버튼 비활성화

### DIFF
--- a/ReadMe-iOS/ReadMe-iOS/Presentation/WriteScene/VC/WriteVC.swift
+++ b/ReadMe-iOS/ReadMe-iOS/Presentation/WriteScene/VC/WriteVC.swift
@@ -215,6 +215,7 @@ extension WriteVC {
     progressBar.setPercentage(ratio: 0.6)
     
     setSecondFlowData()
+    nextButton.isEnabled = false
     UIView.animate(withDuration: 0.4,
                    delay: 0,
                    options: .curveEaseInOut,
@@ -242,7 +243,7 @@ extension WriteVC {
     progressBar.setPercentage(ratio: 1)
     
     thirdView.setData(bookname: bookname ?? "", sentence: quote ?? "")
-    
+    nextButton.isEnabled = false
     UIView.animate(withDuration: 0.4,
                    delay: 0,
                    options: .curveEaseInOut,
@@ -320,15 +321,19 @@ extension WriteVC: UITextViewDelegate {
       if textView.text == "" {
         textView.text = I18N.Write.quotePlaceholder
         textView.textColor = .grey09
+        self.nextButton.isEnabled = false
       } else {
         self.quote = secondView.quoteTextView.text
+        self.nextButton.isEnabled = true
       }
     case thirdView.impressionTextView:
       if textView.text == "" {
         textView.text = I18N.Write.impressionPlaceholder
         textView.textColor = .grey09
+        self.nextButton.isEnabled = false
       } else {
         self.impression = thirdView.impressionTextView.text
+        self.nextButton.isEnabled = true
       }
     default:
       return


### PR DESCRIPTION
## ✨ 작업 내용 
버튼 비활성화
- [x] 최초 secondFlow, thirdFlow 들어갈 때
- [x] textView 입력 끝난 후 작성한 글이 없는 경우


## 📸 스크린샷(선택)

## ⚙️ 관계된 이슈, PR : 
closed #72 

## 📚 레퍼런스 (또는 새로 알게 된 내용) 혹은 궁금한 사항들

